### PR TITLE
Fix / Fix options list

### DIFF
--- a/lib/localized_country_select.rb
+++ b/lib/localized_country_select.rb
@@ -107,7 +107,9 @@ module ActionView
     end
 
     class FormBuilder
-      def localized_country_select(method, priority_countries = nil, options = {}, html_options = {})
+      def localized_country_select(method, options = {}, html_options = {})
+        priority_countries = options.delete(:priority_countries)
+
         @template.localized_country_select(@object_name, method, priority_countries, options.merge(object: @object), html_options)
       end
       alias_method :country_select, :localized_country_select

--- a/lib/localized_country_select/version.rb
+++ b/lib/localized_country_select/version.rb
@@ -1,3 +1,3 @@
 module LocalizedCountrySelect
-  VERSION = '0.10.2'
+  VERSION = '0.10.3'
 end


### PR DESCRIPTION
https://jiraeu.epam.com/browse/EPMTIOOPS-14003

<img width="845" alt="image" src="https://github.com/user-attachments/assets/035838a2-b703-4ac3-bb68-ae034a0a9d4d">

Before upgrade to Rails 7 and country_select gem simple form called SimpleForm::Inputs::PriorityInput#input, which sent priority_countries as a separate argument
<img width="1023" alt="image" src="https://github.com/user-attachments/assets/efd1264d-1260-41a6-9608-cdb40e065611">

After upgrade to Rails 7 and country_select gem, simple form calls SimpleForm::Inputs::PriorityInput#country_input, which puts priority_countries into options hash
<img width="1109" alt="image" src="https://github.com/user-attachments/assets/790ccc69-c24b-44fe-8cc7-d5f301bde9a0">

